### PR TITLE
[FIX] : 🔧 텔레포트 좌표 형태 지정

### DIFF
--- a/app/src/main/java/net/flow9/thisiskotlin/myapplication/Wizard.kt
+++ b/app/src/main/java/net/flow9/thisiskotlin/myapplication/Wizard.kt
@@ -25,7 +25,7 @@ class Wizard {
         println("파이어볼")
     }
 
-    fun teleport() {
+    fun teleport(src:Int,dst:Int) {
         println("${src}에서 ${dst}로 텔레포트")
     }
 }


### PR DESCRIPTION
잘못이해한점 : 메인페이지에서 src,dst좌표를 따로 지정해줘야되는줄 알았다.

이해 : teleport 메소드에서 src,dst 를 Int로 지정해줬다.